### PR TITLE
Add searchable customers table with edit modal

### DIFF
--- a/src/crm/components/CustomersDataGrid.tsx
+++ b/src/crm/components/CustomersDataGrid.tsx
@@ -1,0 +1,250 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import Avatar from "@mui/material/Avatar";
+import Stack from "@mui/material/Stack";
+import IconButton from "@mui/material/IconButton";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    country: string;
+  };
+  phone: string;
+  picture: {
+    thumbnail: string;
+  };
+  registered: {
+    date: string;
+  };
+}
+
+interface CustomersDataGridProps {
+  onEditUser: (user: User) => void;
+}
+
+export default function CustomersDataGrid({
+  onEditUser,
+}: CustomersDataGridProps) {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [filteredUsers, setFilteredUsers] = React.useState<User[]>([]);
+
+  React.useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  React.useEffect(() => {
+    if (searchQuery.trim() === "") {
+      setFilteredUsers(users);
+    } else {
+      const query = searchQuery.toLowerCase();
+      const filtered = users.filter(
+        (user) =>
+          user.name.first.toLowerCase().includes(query) ||
+          user.name.last.toLowerCase().includes(query) ||
+          user.email.toLowerCase().includes(query) ||
+          user.location.city.toLowerCase().includes(query) ||
+          user.location.country.toLowerCase().includes(query),
+      );
+      setFilteredUsers(filtered);
+    }
+  }, [searchQuery, users]);
+
+  const fetchUsers = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(
+        "https://user-api.builder-io.workers.dev/api/users?perPage=100",
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch users");
+      }
+      const data = await response.json();
+      setUsers(data.data || []);
+      setFilteredUsers(data.data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "avatar",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: GridRenderCellParams) => (
+        <Avatar
+          src={params.row.picture?.thumbnail}
+          alt={`${params.row.name.first} ${params.row.name.last}`}
+          sx={{ width: 32, height: 32 }}
+        >
+          {params.row.name.first[0]}
+        </Avatar>
+      ),
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      width: 200,
+      valueGetter: (value, row) =>
+        `${row.name.title} ${row.name.first} ${row.name.last}`,
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      width: 250,
+    },
+    {
+      field: "username",
+      headerName: "Username",
+      width: 150,
+      valueGetter: (value, row) => row.login.username,
+    },
+    {
+      field: "location",
+      headerName: "Location",
+      width: 200,
+      valueGetter: (value, row) =>
+        `${row.location.city}, ${row.location.country}`,
+    },
+    {
+      field: "phone",
+      headerName: "Phone",
+      width: 150,
+    },
+    {
+      field: "registered",
+      headerName: "Registered",
+      width: 130,
+      valueGetter: (value, row) => {
+        const date = new Date(row.registered.date);
+        return date.toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        });
+      },
+    },
+    {
+      field: "actions",
+      headerName: "Actions",
+      width: 100,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: GridRenderCellParams) => (
+        <IconButton
+          size="small"
+          onClick={() => onEditUser(params.row)}
+          aria-label="edit user"
+        >
+          <EditRoundedIcon fontSize="small" />
+        </IconButton>
+      ),
+    },
+  ];
+
+  if (error) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Alert severity="error">{error}</Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="outlined" sx={{ height: 700 }}>
+      <CardContent sx={{ pb: 0 }}>
+        <Stack spacing={2}>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <Typography variant="h6" component="h3">
+              Customer Directory
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {filteredUsers.length} customers
+            </Typography>
+          </Stack>
+          <TextField
+            placeholder="Search customers..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            size="small"
+            fullWidth
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchRoundedIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Stack>
+      </CardContent>
+      <Box sx={{ height: "calc(100% - 120px)", width: "100%", p: 2, pt: 1 }}>
+        {loading ? (
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+          >
+            <CircularProgress />
+          </Box>
+        ) : (
+          <DataGrid
+            rows={filteredUsers}
+            columns={columns}
+            getRowId={(row) => row.login.uuid}
+            pageSizeOptions={[10, 25, 50, 100]}
+            initialState={{
+              pagination: { paginationModel: { pageSize: 25 } },
+            }}
+            disableRowSelectionOnClick
+            density="comfortable"
+            sx={{
+              border: 0,
+              "& .MuiDataGrid-cell:focus": {
+                outline: "none",
+              },
+              "& .MuiDataGrid-cell:focus-within": {
+                outline: "none",
+              },
+            }}
+          />
+        )}
+      </Box>
+    </Card>
+  );
+}

--- a/src/crm/components/EditUserModal.tsx
+++ b/src/crm/components/EditUserModal.tsx
@@ -1,0 +1,278 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Grid from "@mui/material/Grid";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+import Avatar from "@mui/material/Avatar";
+import Stack from "@mui/material/Stack";
+import MenuItem from "@mui/material/MenuItem";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    state?: string;
+    country: string;
+  };
+  phone: string;
+  picture: {
+    thumbnail: string;
+  };
+  registered: {
+    date: string;
+  };
+}
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onUserUpdated: () => void;
+}
+
+export default function EditUserModal({
+  open,
+  user,
+  onClose,
+  onUserUpdated,
+}: EditUserModalProps) {
+  const [formData, setFormData] = React.useState({
+    title: "",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    city: "",
+    state: "",
+    country: "",
+  });
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  React.useEffect(() => {
+    if (user) {
+      setFormData({
+        title: user.name.title || "",
+        firstName: user.name.first || "",
+        lastName: user.name.last || "",
+        email: user.email || "",
+        phone: user.phone || "",
+        city: user.location.city || "",
+        state: user.location.state || "",
+        country: user.location.country || "",
+      });
+      setError(null);
+      setSuccess(false);
+    }
+  }, [user]);
+
+  const handleChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${user.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: {
+              title: formData.title,
+              first: formData.firstName,
+              last: formData.lastName,
+            },
+            email: formData.email,
+            phone: formData.phone,
+            location: {
+              city: formData.city,
+              state: formData.state,
+              country: formData.country,
+            },
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update user");
+      }
+
+      setSuccess(true);
+      setTimeout(() => {
+        onUserUpdated();
+        onClose();
+      }, 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Edit Customer</DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+            <Avatar
+              src={user.picture.thumbnail}
+              sx={{ width: 64, height: 64 }}
+            >
+              {user.name.first[0]}
+            </Avatar>
+            <Box>
+              <Box sx={{ fontWeight: 600, fontSize: "1.1rem" }}>
+                {user.name.first} {user.name.last}
+              </Box>
+              <Box sx={{ color: "text.secondary", fontSize: "0.875rem" }}>
+                @{user.login.username}
+              </Box>
+            </Box>
+          </Stack>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {success && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              User updated successfully!
+            </Alert>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={3}>
+                <TextField
+                  select
+                  label="Title"
+                  value={formData.title}
+                  onChange={(e) => handleChange("title", e.target.value)}
+                  fullWidth
+                  size="small"
+                >
+                  <MenuItem value="Mr">Mr</MenuItem>
+                  <MenuItem value="Mrs">Mrs</MenuItem>
+                  <MenuItem value="Ms">Ms</MenuItem>
+                  <MenuItem value="Miss">Miss</MenuItem>
+                  <MenuItem value="Dr">Dr</MenuItem>
+                </TextField>
+              </Grid>
+              <Grid item xs={12} sm={4.5}>
+                <TextField
+                  label="First Name"
+                  value={formData.firstName}
+                  onChange={(e) => handleChange("firstName", e.target.value)}
+                  fullWidth
+                  required
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12} sm={4.5}>
+                <TextField
+                  label="Last Name"
+                  value={formData.lastName}
+                  onChange={(e) => handleChange("lastName", e.target.value)}
+                  fullWidth
+                  required
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Email"
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => handleChange("email", e.target.value)}
+                  fullWidth
+                  required
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Phone"
+                  value={formData.phone}
+                  onChange={(e) => handleChange("phone", e.target.value)}
+                  fullWidth
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="City"
+                  value={formData.city}
+                  onChange={(e) => handleChange("city", e.target.value)}
+                  fullWidth
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="State"
+                  value={formData.state}
+                  onChange={(e) => handleChange("state", e.target.value)}
+                  fullWidth
+                  size="small"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Country"
+                  value={formData.country}
+                  onChange={(e) => handleChange("country", e.target.value)}
+                  fullWidth
+                  size="small"
+                />
+              </Grid>
+            </Grid>
+          </form>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {loading ? "Saving..." : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,68 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CustomersDataGrid from "../components/CustomersDataGrid";
+import EditUserModal from "../components/EditUserModal";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  email: string;
+  location: {
+    city: string;
+    state?: string;
+    country: string;
+  };
+  phone: string;
+  picture: {
+    thumbnail: string;
+  };
+  registered: {
+    date: string;
+  };
+}
 
 export default function Customers() {
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const [refreshKey, setRefreshKey] = React.useState(0);
+
+  const handleEditUser = (user: User) => {
+    setSelectedUser(user);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleUserUpdated = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
+      <Typography paragraph sx={{ mb: 3, color: "text.secondary" }}>
+        Manage and view your customer database
       </Typography>
+      <CustomersDataGrid key={refreshKey} onEditUser={handleEditUser} />
+      <EditUserModal
+        open={modalOpen}
+        user={selectedUser}
+        onClose={handleCloseModal}
+        onUserUpdated={handleUserUpdated}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
**Purpose**
The goal is to enhance the Customers tab by adding a dashboard populated with data from the Users API. This includes a searchable table for viewing customers and a modal interface to edit their details.

**Code changes**
- **`src/crm/components/CustomersDataGrid.tsx`**: Added a new component that fetches and displays user data in a searchable `DataGrid`.
- **`src/crm/components/EditUserModal.tsx`**: Added a new modal component containing a form to edit user information and save changes via API.
- **`src/crm/pages/Customers.tsx`**: Updated the page to integrate the data grid and edit modal, including state management for user selection and data refreshing.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/81c7d9e6ce8b47abb9742bcc553a7ad5/pixel-lab)

👀 [Preview Link](https://81c7d9e6ce8b47abb9742bcc553a7ad5-pixel-lab.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>81c7d9e6ce8b47abb9742bcc553a7ad5</projectId>-->
<!--<branchName>pixel-lab</branchName>-->