### PR TITLE
Add Coming Soon badge to Contacts page and menu

### DIFF
--- a/src/crm/components/CrmMenuContent.tsx
+++ b/src/crm/components/CrmMenuContent.tsx
@@ -7,6 +7,7 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
 import Divider from "@mui/material/Divider";
 import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
 import PeopleRoundedIcon from "@mui/icons-material/PeopleRounded";
@@ -21,7 +22,12 @@ const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },
   { text: "Customers", icon: <PeopleRoundedIcon />, path: "/customers" },
   { text: "Deals", icon: <BusinessCenterRoundedIcon />, path: "/deals" },
-  { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
+  {
+    text: "Contacts",
+    icon: <ContactsRoundedIcon />,
+    path: "/contacts",
+    comingSoon: true,
+  },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
 ];
@@ -50,6 +56,15 @@ export default function CrmMenuContent() {
             >
               <ListItemIcon>{item.icon}</ListItemIcon>
               <ListItemText primary={item.text} />
+              {(item as any).comingSoon && (
+                <Chip
+                  label="Coming Soon"
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ ml: 1, height: 20, fontSize: "0.65rem" }}
+                />
+              )}
             </ListItemButton>
           </ListItem>
         ))}
@@ -64,8 +79,17 @@ export default function CrmMenuContent() {
                 onClick={() => handleNavigation(item.path)}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
-                <ListItemText primary={item.text} />
-              </ListItemButton>
+              <ListItemText primary={item.text} />
+              {(item as any).comingSoon && (
+                <Chip
+                  label="Coming Soon"
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ ml: 1, height: 20, fontSize: "0.65rem" }}
+                />
+              )}
+            </ListItemButton>
             </ListItem>
           ))}
         </List>

--- a/src/crm/components/CrmSideMenuMobile.tsx
+++ b/src/crm/components/CrmSideMenuMobile.tsx
@@ -9,6 +9,7 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
 import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
 import PeopleRoundedIcon from "@mui/icons-material/PeopleRounded";
 import BusinessCenterRoundedIcon from "@mui/icons-material/BusinessCenterRounded";
@@ -23,7 +24,12 @@ const mainListItems = [
   { text: "Dashboard", icon: <DashboardRoundedIcon />, path: "/" },
   { text: "Customers", icon: <PeopleRoundedIcon />, path: "/customers" },
   { text: "Deals", icon: <BusinessCenterRoundedIcon />, path: "/deals" },
-  { text: "Contacts", icon: <ContactsRoundedIcon />, path: "/contacts" },
+  {
+    text: "Contacts",
+    icon: <ContactsRoundedIcon />,
+    path: "/contacts",
+    comingSoon: true,
+  },
   { text: "Tasks", icon: <AssignmentRoundedIcon />, path: "/tasks" },
   { text: "Reports", icon: <AssessmentRoundedIcon />, path: "/reports" },
 ];
@@ -97,8 +103,17 @@ export default function CrmSideMenuMobile({
                 onClick={() => handleNavigation(item.path)}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
-                <ListItemText primary={item.text} />
-              </ListItemButton>
+              <ListItemText primary={item.text} />
+              {(item as any).comingSoon && (
+                <Chip
+                  label="Coming Soon"
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ ml: 1, height: 20, fontSize: "0.65rem" }}
+                />
+              )}
+            </ListItemButton>
             </ListItem>
           ))}
         </List>
@@ -113,8 +128,17 @@ export default function CrmSideMenuMobile({
                 onClick={() => handleNavigation(item.path)}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
-                <ListItemText primary={item.text} />
-              </ListItemButton>
+              <ListItemText primary={item.text} />
+              {(item as any).comingSoon && (
+                <Chip
+                  label="Coming Soon"
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ ml: 1, height: 20, fontSize: "0.65rem" }}
+                />
+              )}
+            </ListItemButton>
             </ListItem>
           ))}
         </List>

--- a/src/crm/pages/Contacts.tsx
+++ b/src/crm/pages/Contacts.tsx
@@ -1,13 +1,18 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
+import Stack from "@mui/material/Stack";
 
 export default function Contacts() {
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Contacts Page
-      </Typography>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 4 }}>
+        <Typography variant="h4" component="h1">
+          Contacts Page
+        </Typography>
+        <Chip label="Coming Soon" color="primary" variant="outlined" />
+      </Stack>
       <Typography paragraph>
         This is the contacts management page where you can organize and manage
         your business contacts.


### PR DESCRIPTION
### Summary
This PR adds a visual "Coming Soon" indicator to the Contacts section in the CRM navigation menus and on the Contacts page itself.

### Problem
The Contacts feature is currently in development or incomplete, and users needed a visual cue indicating its status within the application.

### Solution
Added a `Chip` component labeled "Coming Soon" to the Contacts navigation item in both desktop and mobile menus, as well as next to the title on the Contacts page.

### Key Changes
*   Added `comingSoon` property to the Contacts configuration in `mainListItems`.
*   Updated `CrmMenuContent` and `CrmSideMenuMobile` to render a "Coming Soon" chip for flagged menu items.
*   Added a "Coming Soon" chip next to the header in `src/crm/pages/Contacts.tsx`.

---

<a href="https://builder.io/app/projects/af7f927d3d1845d29994f2da5c142add/curry-forge"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://af7f927d3d1845d29994f2da5c142add-curry-forge.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>af7f927d3d1845d29994f2da5c142add</projectId>-->
<!--<branchName>curry-forge</branchName>-->